### PR TITLE
地上波の録画指定オプションを有効化

### DIFF
--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -61,8 +61,8 @@ func (s *syncer) registerRulesToEpgStation(ctx context.Context, titles []string)
 			}
 			body := epgstation.PostRulesJSONRequestBody{
 				SearchOption: epgstation.RuleSearchOption{
-					SKY: epgstation.NewTruePointer(),
-					BS:  epgstation.NewTruePointer(),
+					GR: epgstation.NewFalsePointer(),
+					BS: epgstation.NewTruePointer(),
 
 					Keyword:     &title,
 					Description: epgstation.NewTruePointer(),


### PR DESCRIPTION
誤ったオプション（SKY）が設定されていたものを正しいもの（GR）へ修正。