### PR TITLE
Disable AvoidDuplicate option

### DIFF
--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -104,7 +104,7 @@ func (s *syncer) registerRulesToEpgStation(ctx context.Context, titles []string)
 				SaveOption:          &epgstation.ReserveSaveOption{},
 				EncodeOption:        &epgstation.ReserveEncodedOption{},
 				ReserveOption: epgstation.RuleReserveOption{
-					AvoidDuplicate: true,
+					AvoidDuplicate: false,
 					Enable:         true,
 					AllowEndLack:   false,
 				},


### PR DESCRIPTION
EPGStation側でfalse positiveが多いので無効化する。

例えば以下のような場合に重複排除が発動して消える

- 番組名に話数を含めないので話数を跨いでタイトルが同じになる（例：テレ東）