### PR TITLE
Add Dockerfile and workflows to build images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       -
         name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,5 +49,5 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
     branches: 
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Build container images
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+    branches: 
+      - main
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM --platform=$BUILDPLATFORM golang:1.20 AS builder
+
+WORKDIR /workspace
+COPY . /workspace
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o annict-epgstation-connector ./cmd/annict-epgstation-connector
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/annict-epgstation-connector .
+USER 65532:65532
+
+ENTRYPOINT ["/annict-epgstation-connector"]


### PR DESCRIPTION
## WHY
I'd like to use this on Kubernetes!

## WHAT
Closes #11

- Add Dockerfile
- Add a workflow to build images

## QA
https://github.com/tsuzu/annict-epgstation-connector/actions/runs/5414716816/jobs/9842163134

```
tsuzu@Tsuzus-MacBook-Pro annict-epgstation-connector % docker run -ti --rm ghcr.io/tsuzu/annict-epgstation-connector:sha-450bf23 --help
Unable to find image 'ghcr.io/tsuzu/annict-epgstation-connector:sha-450bf23' locally
sha-450bf23: Pulling from tsuzu/annict-epgstation-connector
0b41f743fd4d: Already exists 
fe5ca62666f0: Already exists 
b02a7525f878: Already exists 
fcb6f6d2c998: Already exists 
e8c73c638ae9: Already exists 
1e3d9b7d1452: Already exists 
4aa0ea1413d3: Already exists 
7c881f9ab25e: Already exists 
5627a970d25e: Already exists 
34fb4f507127: Pull complete 
Digest: sha256:572262d8437f7f17ceeb271b9f4e3829a94f565bda162277e3a1094da07abaa7
Status: Downloaded newer image for ghcr.io/tsuzu/annict-epgstation-connector:sha-450bf23
NAME:
   annict-epgstation-connector - generate recording rules based on the annict statuses

USAGE:
   annict-epgstation-connector [global options] command [command options] [arguments...]

COMMANDS:
   sync     sync
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --annict-api-token value     An API token of annict GraphQL API server [$ANNICT_API_TOKEN]
   --epgstation-endpoint value  An endpoint of EPGStation API server [$EPGSTATION_ENDPOINT]
   --help, -h                   show help
tsuzu@Tsuzus-MacBook-Pro annict-epgstation-connector % 
```
