### PR TITLE
Annictから放送開始日のデータをとってくるように変更

### DIFF
--- a/annict/generated.go
+++ b/annict/generated.go
@@ -46,15 +46,15 @@ func (v *GetOnHoldWorksViewerUserWorksWorkConnection) GetNodes() []GetOnHoldWork
 //
 // An anime title
 type GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork struct {
-	Id         string                                                                        `json:"id"`
+	AnnictId   int                                                                           `json:"annictId"`
 	Title      string                                                                        `json:"title"`
 	SeasonName SeasonName                                                                    `json:"seasonName"`
 	SeasonYear int                                                                           `json:"seasonYear"`
 	Programs   GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection `json:"programs"`
 }
 
-// GetId returns GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork.Id, and is useful for accessing the field via an interface.
-func (v *GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork) GetId() string { return v.Id }
+// GetAnnictId returns GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork.AnnictId, and is useful for accessing the field via an interface.
+func (v *GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork) GetAnnictId() int { return v.AnnictId }
 
 // GetTitle returns GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork.Title, and is useful for accessing the field via an interface.
 func (v *GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork) GetTitle() string { return v.Title }
@@ -135,15 +135,17 @@ func (v *GetWannaWatchWorksViewerUserWorksWorkConnection) GetNodes() []GetWannaW
 //
 // An anime title
 type GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork struct {
-	Id         string                                                                            `json:"id"`
+	AnnictId   int                                                                               `json:"annictId"`
 	Title      string                                                                            `json:"title"`
 	SeasonName SeasonName                                                                        `json:"seasonName"`
 	SeasonYear int                                                                               `json:"seasonYear"`
 	Programs   GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection `json:"programs"`
 }
 
-// GetId returns GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork.Id, and is useful for accessing the field via an interface.
-func (v *GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork) GetId() string { return v.Id }
+// GetAnnictId returns GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork.AnnictId, and is useful for accessing the field via an interface.
+func (v *GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork) GetAnnictId() int {
+	return v.AnnictId
+}
 
 // GetTitle returns GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork.Title, and is useful for accessing the field via an interface.
 func (v *GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork) GetTitle() string { return v.Title }
@@ -224,15 +226,15 @@ func (v *GetWatchingWorksViewerUserWorksWorkConnection) GetNodes() []GetWatching
 //
 // An anime title
 type GetWatchingWorksViewerUserWorksWorkConnectionNodesWork struct {
-	Id         string                                                                          `json:"id"`
+	AnnictId   int                                                                             `json:"annictId"`
 	Title      string                                                                          `json:"title"`
 	SeasonName SeasonName                                                                      `json:"seasonName"`
 	SeasonYear int                                                                             `json:"seasonYear"`
 	Programs   GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection `json:"programs"`
 }
 
-// GetId returns GetWatchingWorksViewerUserWorksWorkConnectionNodesWork.Id, and is useful for accessing the field via an interface.
-func (v *GetWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetId() string { return v.Id }
+// GetAnnictId returns GetWatchingWorksViewerUserWorksWorkConnectionNodesWork.AnnictId, and is useful for accessing the field via an interface.
+func (v *GetWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetAnnictId() int { return v.AnnictId }
 
 // GetTitle returns GetWatchingWorksViewerUserWorksWorkConnectionNodesWork.Title, and is useful for accessing the field via an interface.
 func (v *GetWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetTitle() string { return v.Title }
@@ -292,7 +294,7 @@ query GetOnHoldWorks {
 	viewer {
 		works(state: WATCHING) {
 			nodes {
-				id
+				annictId
 				title
 				seasonName
 				seasonYear
@@ -335,7 +337,7 @@ query GetWannaWatchWorks {
 	viewer {
 		works(state: WANNA_WATCH) {
 			nodes {
-				id
+				annictId
 				title
 				seasonName
 				seasonYear
@@ -378,7 +380,7 @@ query GetWatchingWorks {
 	viewer {
 		works(state: WATCHING) {
 			nodes {
-				id
+				annictId
 				title
 				seasonName
 				seasonYear

--- a/annict/generated.go
+++ b/annict/generated.go
@@ -4,6 +4,7 @@ package annict
 
 import (
 	"context"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 )
@@ -45,10 +46,11 @@ func (v *GetOnHoldWorksViewerUserWorksWorkConnection) GetNodes() []GetOnHoldWork
 //
 // An anime title
 type GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork struct {
-	Id         string     `json:"id"`
-	Title      string     `json:"title"`
-	SeasonName SeasonName `json:"seasonName"`
-	SeasonYear int        `json:"seasonYear"`
+	Id         string                                                                        `json:"id"`
+	Title      string                                                                        `json:"title"`
+	SeasonName SeasonName                                                                    `json:"seasonName"`
+	SeasonYear int                                                                           `json:"seasonYear"`
+	Programs   GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection `json:"programs"`
 }
 
 // GetId returns GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork.Id, and is useful for accessing the field via an interface.
@@ -65,6 +67,35 @@ func (v *GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonName() S
 // GetSeasonYear returns GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork.SeasonYear, and is useful for accessing the field via an interface.
 func (v *GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonYear() int {
 	return v.SeasonYear
+}
+
+// GetPrograms returns GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork.Programs, and is useful for accessing the field via an interface.
+func (v *GetOnHoldWorksViewerUserWorksWorkConnectionNodesWork) GetPrograms() GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection {
+	return v.Programs
+}
+
+// GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection includes the requested fields of the GraphQL type ProgramConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for Program.
+type GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection struct {
+	// A list of nodes.
+	Nodes []GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram `json:"nodes"`
+}
+
+// GetNodes returns GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection) GetNodes() []GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram {
+	return v.Nodes
+}
+
+// GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram includes the requested fields of the GraphQL type Program.
+type GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram struct {
+	StartedAt time.Time `json:"startedAt"`
+}
+
+// GetStartedAt returns GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram.StartedAt, and is useful for accessing the field via an interface.
+func (v *GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram) GetStartedAt() time.Time {
+	return v.StartedAt
 }
 
 // GetWannaWatchWorksResponse is returned by GetWannaWatchWorks on success.
@@ -104,10 +135,11 @@ func (v *GetWannaWatchWorksViewerUserWorksWorkConnection) GetNodes() []GetWannaW
 //
 // An anime title
 type GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork struct {
-	Id         string     `json:"id"`
-	Title      string     `json:"title"`
-	SeasonName SeasonName `json:"seasonName"`
-	SeasonYear int        `json:"seasonYear"`
+	Id         string                                                                            `json:"id"`
+	Title      string                                                                            `json:"title"`
+	SeasonName SeasonName                                                                        `json:"seasonName"`
+	SeasonYear int                                                                               `json:"seasonYear"`
+	Programs   GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection `json:"programs"`
 }
 
 // GetId returns GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork.Id, and is useful for accessing the field via an interface.
@@ -124,6 +156,35 @@ func (v *GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonName
 // GetSeasonYear returns GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork.SeasonYear, and is useful for accessing the field via an interface.
 func (v *GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonYear() int {
 	return v.SeasonYear
+}
+
+// GetPrograms returns GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork.Programs, and is useful for accessing the field via an interface.
+func (v *GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWork) GetPrograms() GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection {
+	return v.Programs
+}
+
+// GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection includes the requested fields of the GraphQL type ProgramConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for Program.
+type GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection struct {
+	// A list of nodes.
+	Nodes []GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram `json:"nodes"`
+}
+
+// GetNodes returns GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection) GetNodes() []GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram {
+	return v.Nodes
+}
+
+// GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram includes the requested fields of the GraphQL type Program.
+type GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram struct {
+	StartedAt time.Time `json:"startedAt"`
+}
+
+// GetStartedAt returns GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram.StartedAt, and is useful for accessing the field via an interface.
+func (v *GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram) GetStartedAt() time.Time {
+	return v.StartedAt
 }
 
 // GetWatchingWorksResponse is returned by GetWatchingWorks on success.
@@ -163,10 +224,11 @@ func (v *GetWatchingWorksViewerUserWorksWorkConnection) GetNodes() []GetWatching
 //
 // An anime title
 type GetWatchingWorksViewerUserWorksWorkConnectionNodesWork struct {
-	Id         string     `json:"id"`
-	Title      string     `json:"title"`
-	SeasonName SeasonName `json:"seasonName"`
-	SeasonYear int        `json:"seasonYear"`
+	Id         string                                                                          `json:"id"`
+	Title      string                                                                          `json:"title"`
+	SeasonName SeasonName                                                                      `json:"seasonName"`
+	SeasonYear int                                                                             `json:"seasonYear"`
+	Programs   GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection `json:"programs"`
 }
 
 // GetId returns GetWatchingWorksViewerUserWorksWorkConnectionNodesWork.Id, and is useful for accessing the field via an interface.
@@ -183,6 +245,35 @@ func (v *GetWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonName()
 // GetSeasonYear returns GetWatchingWorksViewerUserWorksWorkConnectionNodesWork.SeasonYear, and is useful for accessing the field via an interface.
 func (v *GetWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonYear() int {
 	return v.SeasonYear
+}
+
+// GetPrograms returns GetWatchingWorksViewerUserWorksWorkConnectionNodesWork.Programs, and is useful for accessing the field via an interface.
+func (v *GetWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetPrograms() GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection {
+	return v.Programs
+}
+
+// GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection includes the requested fields of the GraphQL type ProgramConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for Program.
+type GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection struct {
+	// A list of nodes.
+	Nodes []GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram `json:"nodes"`
+}
+
+// GetNodes returns GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection) GetNodes() []GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram {
+	return v.Nodes
+}
+
+// GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram includes the requested fields of the GraphQL type Program.
+type GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram struct {
+	StartedAt time.Time `json:"startedAt"`
+}
+
+// GetStartedAt returns GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram.StartedAt, and is useful for accessing the field via an interface.
+func (v *GetWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram) GetStartedAt() time.Time {
+	return v.StartedAt
 }
 
 // Season name
@@ -205,6 +296,11 @@ query GetOnHoldWorks {
 				title
 				seasonName
 				seasonYear
+				programs(first: 1) {
+					nodes {
+						startedAt
+					}
+				}
 			}
 		}
 	}
@@ -243,6 +339,11 @@ query GetWannaWatchWorks {
 				title
 				seasonName
 				seasonYear
+				programs(first: 1) {
+					nodes {
+						startedAt
+					}
+				}
 			}
 		}
 	}
@@ -281,6 +382,11 @@ query GetWatchingWorks {
 				title
 				seasonName
 				seasonYear
+				programs(first: 1) {
+					nodes {
+						startedAt
+					}
+				}
 			}
 		}
 	}

--- a/annict/query.graphql
+++ b/annict/query.graphql
@@ -2,7 +2,7 @@ query GetWannaWatchWorks {
   viewer {
     works(state: WANNA_WATCH){
       nodes {
-        id
+        annictId
         title
         seasonName
         seasonYear
@@ -20,7 +20,7 @@ query GetWatchingWorks {
   viewer {
     works(state: WATCHING){
       nodes {
-        id
+        annictId
         title
         seasonName
         seasonYear
@@ -38,7 +38,7 @@ query GetOnHoldWorks {
   viewer {
     works(state: WATCHING){
       nodes {
-        id
+        annictId
         title
         seasonName
         seasonYear

--- a/annict/query.graphql
+++ b/annict/query.graphql
@@ -6,6 +6,11 @@ query GetWannaWatchWorks {
         title
         seasonName
         seasonYear
+        programs (first: 1) {
+          nodes {
+            startedAt
+          }
+        }
       }
     }
   }
@@ -19,6 +24,11 @@ query GetWatchingWorks {
         title
         seasonName
         seasonYear
+        programs (first: 1) {
+          nodes {
+            startedAt
+          }
+        }
       }
     }
   }
@@ -32,6 +42,11 @@ query GetOnHoldWorks {
         title
         seasonName
         seasonYear
+        programs (first: 1) {
+          nodes {
+            startedAt
+          }
+        }
       }
     }
   }

--- a/internal/syncer/metrics.go
+++ b/internal/syncer/metrics.go
@@ -71,7 +71,7 @@ var (
 			Namespace: namespace,
 			Subsystem: "syncer",
 			Name:      "annict_work_started_at",
-			Help:      "The time when the annict work is going to start or started broadcasting.",
+			Help:      "The Unix timestamp when the annict work is going to start or started broadcasting.",
 		},
 		[]string{
 			"id",

--- a/internal/syncer/metrics.go
+++ b/internal/syncer/metrics.go
@@ -13,6 +13,7 @@ func init() {
 	prometheus.MustRegister(syncerSyncSuccess)
 	prometheus.MustRegister(syncerSyncError)
 	prometheus.MustRegister(syncerRecordingRuleSynced)
+	prometheus.MustRegister(syncerAnnictWorkStartedAt)
 }
 
 var (
@@ -61,6 +62,22 @@ var (
 		[]string{
 			"rule_id",
 			"annict_work_id",
+		},
+	)
+
+	// syncerAnnictWorkStartedAt is a gauge of the time when the annict work is going to start or started broadcasting.
+	syncerAnnictWorkStartedAt = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "syncer",
+			Name:      "annict_work_started_at",
+			Help:      "The time when the annict work is going to start or started broadcasting.",
+		},
+		[]string{
+			"id",
+			"title",
+			"season_name",
+			"season_year",
 		},
 	)
 )

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -148,6 +148,13 @@ func (s *syncer) registerRulesToEpgStation(ctx context.Context, works []annictWo
 	for _, work := range works {
 		work := work
 		eg.Go(func() error {
+			syncerAnnictWorkStartedAt.WithLabelValues(
+				work.ID,
+				work.Title,
+				work.SeasonName,
+				strconv.Itoa(work.SeasonYear),
+			).Set(float64(work.StartedAt.Unix()))
+
 			ruleIDs, err := s.getRecordingRuleIDsByAnnictWorkID(work.ID)
 			switch {
 			case err != nil && !errors.Is(err, pebble.ErrNotFound):

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -252,7 +252,7 @@ func (s *syncer) getWannaWatchWorks(ctx context.Context) ([]annictWork, error) {
 	}
 	for _, n := range r.Viewer.Works.Nodes {
 		titles = append(titles, annictWork{
-			ID:         n.Id,
+			ID:         strconv.Itoa(n.AnnictId),
 			Title:      n.Title,
 			SeasonName: string(n.SeasonName),
 			SeasonYear: n.SeasonYear,
@@ -269,7 +269,7 @@ func (s *syncer) getWatchingWorks(ctx context.Context) ([]annictWork, error) {
 	}
 	for _, n := range r.Viewer.Works.Nodes {
 		titles = append(titles, annictWork{
-			ID:         n.Id,
+			ID:         strconv.Itoa(n.AnnictId),
 			Title:      n.Title,
 			SeasonName: string(n.SeasonName),
 			SeasonYear: n.SeasonYear,
@@ -286,7 +286,7 @@ func (s *syncer) getOnHoldWorks(ctx context.Context) ([]annictWork, error) {
 	}
 	for _, n := range r.Viewer.Works.Nodes {
 		titles = append(titles, annictWork{
-			ID:         n.Id,
+			ID:         strconv.Itoa(n.AnnictId),
 			Title:      n.Title,
 			SeasonName: string(n.SeasonName),
 			SeasonYear: n.SeasonYear,

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -251,11 +251,16 @@ func (s *syncer) getWannaWatchWorks(ctx context.Context) ([]annictWork, error) {
 		return titles, fmt.Errorf("failed to sync: %w", err)
 	}
 	for _, n := range r.Viewer.Works.Nodes {
+		var startedAt time.Time
+		if len(n.Programs.Nodes) != 0 {
+			startedAt = n.Programs.Nodes[0].StartedAt
+		}
 		titles = append(titles, annictWork{
 			ID:         strconv.Itoa(n.AnnictId),
 			Title:      n.Title,
 			SeasonName: string(n.SeasonName),
 			SeasonYear: n.SeasonYear,
+			StartedAt:  startedAt,
 		})
 	}
 	return titles, nil
@@ -268,11 +273,16 @@ func (s *syncer) getWatchingWorks(ctx context.Context) ([]annictWork, error) {
 		return titles, fmt.Errorf("failed to sync: %w", err)
 	}
 	for _, n := range r.Viewer.Works.Nodes {
+		var startedAt time.Time
+		if len(n.Programs.Nodes) != 0 {
+			startedAt = n.Programs.Nodes[0].StartedAt
+		}
 		titles = append(titles, annictWork{
 			ID:         strconv.Itoa(n.AnnictId),
 			Title:      n.Title,
 			SeasonName: string(n.SeasonName),
 			SeasonYear: n.SeasonYear,
+			StartedAt:  startedAt,
 		})
 	}
 	return titles, nil
@@ -285,11 +295,16 @@ func (s *syncer) getOnHoldWorks(ctx context.Context) ([]annictWork, error) {
 		return titles, fmt.Errorf("failed to sync: %w", err)
 	}
 	for _, n := range r.Viewer.Works.Nodes {
+		var startedAt time.Time
+		if len(n.Programs.Nodes) != 0 {
+			startedAt = n.Programs.Nodes[0].StartedAt
+		}
 		titles = append(titles, annictWork{
 			ID:         strconv.Itoa(n.AnnictId),
 			Title:      n.Title,
 			SeasonName: string(n.SeasonName),
 			SeasonYear: n.SeasonYear,
+			StartedAt:  startedAt,
 		})
 	}
 	return titles, nil

--- a/internal/syncer/types.go
+++ b/internal/syncer/types.go
@@ -1,10 +1,14 @@
 package syncer
 
+import "time"
+
 type annictWork struct {
 	ID         string
 	SeasonName string
 	SeasonYear int
 	Title      string
+	// StartedAt represents the time when the work is going to start or started broadcasting.
+	StartedAt time.Time
 }
 
 type RecordingRuleID int


### PR DESCRIPTION

```
❯ curl -s localhost:8080/metrics | grep started_at | head
# HELP annict_epgstation_connector_syncer_annict_work_started_at The time when the annict work is going to start or started broadcasting.
# TYPE annict_epgstation_connector_syncer_annict_work_started_at gauge
annict_epgstation_connector_syncer_annict_work_started_at{id="10042",season_name="AUTUMN",season_year="2023",title="アンデッドアンラック"} 1.69660968e+09
annict_epgstation_connector_syncer_annict_work_started_at{id="10071",season_name="AUTUMN",season_year="2023",title="ティアムーン帝国物語～断頭台から始まる、姫の転生逆転ストーリー～"} 1.6966944e+09
annict_epgstation_connector_syncer_annict_work_started_at{id="10079",season_name="AUTUMN",season_year="2023",title="葬送のフリーレン"} 1.6959888e+09
annict_epgstation_connector_syncer_annict_work_started_at{id="10083",season_name="",season_year="0",title="『原神』アニメ"} -6.21355968e+10
annict_epgstation_connector_syncer_annict_work_started_at{id="10096",season_name="",season_year="2024",title="ATRI -My Dear Moments-"} -6.21355968e+10
annict_epgstation_connector_syncer_annict_work_started_at{id="10098",season_name="SPRING",season_year="2023",title="青春ブタ野郎はおでかけシスターの夢を見ない"} -6.21355968e+10
annict_epgstation_connector_syncer_annict_work_started_at{id="10099",season_name="AUTUMN",season_year="2023",title="青春ブタ野郎はランドセルガールの夢を見ない"} -6.21355968e+10
annict_epgstation_connector_syncer_annict_work_started_at{id="10132",season_name="SPRING",season_year="2023",title="天国大魔境"} 1.680354e+09
```