### PR TITLE
fix: replace deprecated --rm-dist flag with --clean in goreleaser workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Summary
- Replaced deprecated `--rm-dist` flag with `--clean` in the goreleaser workflow
- This fixes the failing release workflow that was preventing project releases

## Details
The `--rm-dist` flag was deprecated in GoReleaser v1.0.0 and replaced with `--clean`. The workflow was failing because of this deprecated flag usage.

## Test plan
- [x] Created fix and pushed to branch
- [x] Verify that the release workflow runs successfully with the new flag
- [ ] Test by creating a release tag once merged